### PR TITLE
Fix options_page deprecation in Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,7 @@
   "background": {
     "scripts": ["js/eventPage.js"]
   },
-  "options_page": "options.html"
+  "options_ui": {
+    "page": "options.html"
+  }
 }


### PR DESCRIPTION
* manifest.json: The “options_page” key in the manifest file is deprecated in Firefox and using this key prevent using the extension in Firefox[1].  Using the “options_ui” offers more browser support.

[1] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page